### PR TITLE
Enhance uppercase trait configuration and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,121 @@
 # Laravel To Upper
 
-## 📌 Sobre o Projeto
-O **Laravel To Upper** é um package para Laravel que coloca em maiusculo dados do ao serem inseridos no banco de dados.
+Um pacote Laravel que normaliza atributos de modelos para letras maiúsculas antes de persistir os dados. A trait `HasToUpper` integra-se ao pipeline padrão do Eloquent, respeitando mutators, casts e listas configuráveis de exceção.
 
 ---
 
 ## 🚀 Instalação
 
-### 1️⃣ Requisitos
-Antes de instalar, certifique-se de que seu projeto atenda aos seguintes requisitos:
-- PHP >= 8.0
-- Laravel >= 10
-- Composer instalado
-
-### 2️⃣ Instalação do Package
-Execute o seguinte comando no terminal:
 ```bash
-  composer require risetechapps/to-upper-for-laravel
+composer require risetechapps/to-upper-for-laravel
 ```
 
-### 3️⃣ Configurar Model
+Opcionalmente publique a configuração para personalizar o comportamento global:
+
 ```bash
-  use RiseTechApps\ToUpper\Traits\HasToUpper;
-  
-  class Client extends Model
-  {
-    use HasFactory, HasToUpper;
-  }
+php artisan vendor:publish --provider="RiseTechApps\\ToUpper\\ToUpperServiceProvider" --tag=config
 ```
 
 ---
 
-## 🛠 Contribuição
-Sinta-se à vontade para contribuir! Basta seguir estes passos:
+## ⚙️ Uso básico
+
+```php
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use RiseTechApps\ToUpper\Traits\HasToUpper;
+
+class Client extends Model
+{
+    use HasFactory, HasToUpper;
+}
+```
+
+Atribuições de strings serão convertidas para maiúsculo (UTF-8 por padrão) antes de chegarem ao array interno de atributos do Eloquent:
+
+```php
+$client = new Client();
+$client->name = 'joão silva';
+$client->city = ' porto alegre ';
+
+$client->name; // JOÃO SILVA
+$client->city; // PORTO ALEGRE (trim aplicado por padrão)
+```
+
+---
+
+## 🧩 Configuração avançada
+
+### Listas de controle
+
+No model, defina as propriedades abaixo para controlar quais atributos devem (ou não) ser normalizados. As listas são mescladas com os valores definidos em `config/to-upper.php`.
+
+```php
+class Client extends Model
+{
+    use HasToUpper;
+
+    protected array $only_upper = ['code'];      // apenas estes atributos serão convertidos
+    protected array $no_upper   = ['email'];     // estes atributos nunca serão convertidos
+    protected array $ignore_upper = ['notes'];   // ignora atributos adicionais
+}
+```
+
+Quando `only_upper` não estiver vazia, somente os atributos informados serão convertidos. Caso contrário, todos os atributos string serão normalizados, exceto aqueles presentes em `no_upper`, `ignore_upper` ou que representem relacionamentos morph (`*_type`, `*_id` por padrão).
+
+### Codificação e trim
+
+Controle da codificação e do comportamento de `trim` por model:
+
+```php
+class Client extends Model
+{
+    use HasToUpper;
+
+    protected string $uppercase_encoding = 'ISO-8859-1';
+    protected bool $uppercase_trim = false; // mantém espaços ao redor
+}
+```
+
+Ou ajuste globalmente via arquivo de configuração publicado:
+
+```php
+return [
+    'encoding' => 'UTF-8',
+    'trim' => true,
+    'only_upper' => [],
+    'no_upper' => [],
+    'ignore_attributes' => ['id', 'password', 'remember_token'],
+    'morph_suffixes' => ['_type', '_id'],
+];
+```
+
+---
+
+## 🧪 Testes
+
+O pacote possui uma suíte com Orchestra Testbench. Para executá-la:
+
+```bash
+composer install
+composer test
+```
+
+---
+
+## 🤝 Contribuição
+
 1. Faça um fork do repositório
 2. Crie uma branch (`feature/nova-funcionalidade`)
-3. Faça um commit das suas alterações
+3. Faça commit das suas alterações
 4. Envie um Pull Request
 
 ---
 
 ## 📜 Licença
+
 Este projeto é distribuído sob a licença MIT. Veja o arquivo [LICENSE](LICENSE) para mais detalhes.
 
 ---
 
 💡 **Desenvolvido por [Rise Tech](https://risetech.com.br)**
-

--- a/config/config.php
+++ b/config/config.php
@@ -1,8 +1,49 @@
 <?php
 
-/*
- * You can place your custom package configuration in here.
- */
 return [
+    /*
+     * Encoding used when converting strings to uppercase. If null, the
+     * current internal encoding configured in PHP will be used.
+     */
+    'encoding' => 'UTF-8',
 
+    /*
+     * Whether the value should be trimmed after applying the upper conversion.
+     */
+    'trim' => true,
+
+    /*
+     * Attributes that should always be converted to uppercase. When this list
+     * is not empty, only the attributes listed here will be normalized.
+     */
+    'only_upper' => [],
+
+    /*
+     * Attributes that should never be converted to uppercase.
+     */
+    'no_upper' => [],
+
+    /*
+     * Attributes that should be ignored by default. These values can still be
+     * overridden on a per-model basis using the `$only_upper` or `$no_upper`
+     * properties.
+     */
+    'ignore_attributes' => [
+        'id',
+        'password',
+        'password_confirm',
+        'remember_token',
+        'slug',
+        'language',
+        'tenant',
+        'tenant_branch',
+        'model_auth',
+        'model',
+    ],
+
+    /*
+     * Attribute suffixes that identify morph relationship columns. Any
+     * attribute containing the suffix will be ignored.
+     */
+    'morph_suffixes' => ['_type', '_id'],
 ];

--- a/src/ToUpper.php
+++ b/src/ToUpper.php
@@ -2,7 +2,30 @@
 
 namespace RiseTechApps\ToUpper;
 
+use Illuminate\Support\Arr;
+
 class ToUpper
 {
+    public function __construct(private array $config = [])
+    {
+    }
 
+    public function normalize(string $value, ?string $encoding = null, ?bool $trim = null): string
+    {
+        $encoding ??= $this->config('encoding', mb_internal_encoding());
+        $trim ??= $this->config('trim', true);
+
+        $normalized = mb_strtoupper($value, $encoding);
+
+        return $trim ? trim($normalized) : $normalized;
+    }
+
+    public function config(?string $key = null, mixed $default = null): mixed
+    {
+        if ($key === null) {
+            return $this->config;
+        }
+
+        return Arr::get($this->config, $key, $default);
+    }
 }

--- a/src/ToUpperFacade.php
+++ b/src/ToUpperFacade.php
@@ -5,16 +5,11 @@ namespace RiseTechApps\ToUpper;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \RiseTechApps\ToUpper\Skeleton\SkeletonClass
+ * @see \RiseTechApps\ToUpper\ToUpper
  */
 class ToUpperFacade extends Facade
 {
-    /**
-     * Get the registered name of the component.
-     *
-     * @return string
-     */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'to-upper';
     }

--- a/src/ToUpperServiceProvider.php
+++ b/src/ToUpperServiceProvider.php
@@ -6,19 +6,23 @@ use Illuminate\Support\ServiceProvider;
 
 class ToUpperServiceProvider extends ServiceProvider
 {
-    /**
-     * Bootstrap the application services.
-     */
-    public function boot()
+    public function boot(): void
     {
-
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/../config/config.php' => config_path('to-upper.php'),
+            ], 'config');
+        }
     }
 
-    /**
-     * Register the application services.
-     */
-    public function register()
+    public function register(): void
     {
+        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'to-upper');
 
+        $this->app->singleton(ToUpper::class, function ($app) {
+            return new ToUpper($app['config']->get('to-upper', []));
+        });
+
+        $this->app->alias(ToUpper::class, 'to-upper');
     }
 }

--- a/src/Traits/HasToUpper.php
+++ b/src/Traits/HasToUpper.php
@@ -2,46 +2,109 @@
 
 namespace RiseTechApps\ToUpper\Traits;
 
+use RiseTechApps\ToUpper\ToUpper;
+
 trait HasToUpper
 {
-
-    public function setAttribute($key, $value): void
+    public function setAttribute($key, $value)
     {
-        parent::setAttribute($key, $value);
-
         if (is_string($value) && $this->shouldConvertToUpper($key)) {
-            $this->attributes[$key] = trim(mb_strtoupper($value));
+            $value = $this->getToUpperService()->normalize(
+                $value,
+                $this->resolveEncoding(),
+                $this->shouldTrim()
+            );
         }
+
+        return parent::setAttribute($key, $value);
     }
 
     private function shouldConvertToUpper($key): bool
     {
-        $onlyUpper = property_exists($this, 'only_upper') && is_array($this->only_upper) ? $this->only_upper : [];
+        $onlyUpper = $this->resolveOnlyUpperAttributes();
         if (!empty($onlyUpper)) {
-            return in_array($key, $onlyUpper);
+            return in_array($key, $onlyUpper, true);
         }
 
-        $no_upper = property_exists($this, 'no_upper') && is_array($this->no_upper) ? $this->no_upper : [];
+        $noUpper = $this->resolveNoUpperAttributes();
 
-        return !$this->isIgnore($key) && !$this->isMorph($key) && !in_array($key, $no_upper);
+        return !$this->isIgnoredAttribute($key)
+            && !$this->isMorphAttribute($key)
+            && !in_array($key, $noUpper, true);
     }
 
-    protected function isIgnore($key): bool
+    protected function resolveOnlyUpperAttributes(): array
     {
-        return in_array($key, [
-            'id', 'password', 'password_confirm', 'remember_token',
-            'slug', 'language', 'tenant', 'tenant_branch',
-            'model_auth', 'model'
-        ]);
+        return $this->mergeConfiguredAttributes('only_upper');
     }
 
-    protected function isMorph($key): bool
+    protected function resolveNoUpperAttributes(): array
     {
-        foreach ( ['_type', '_id'] as $morph) {
-            if (str_contains($key, $morph)) {
+        return $this->mergeConfiguredAttributes('no_upper');
+    }
+
+    protected function isIgnoredAttribute(string $key): bool
+    {
+        $ignore = $this->mergeConfiguredAttributes('ignore_attributes', 'ignore_upper');
+
+        return in_array($key, $ignore, true);
+    }
+
+    protected function isMorphAttribute(string $key): bool
+    {
+        $suffixes = $this->mergeConfiguredAttributes('morph_suffixes');
+
+        foreach ($suffixes as $suffix) {
+            if ($suffix !== '' && str_contains($key, $suffix)) {
                 return true;
             }
         }
+
         return false;
+    }
+
+    protected function shouldTrim(): bool
+    {
+        if (property_exists($this, 'uppercase_trim')) {
+            return (bool) $this->uppercase_trim;
+        }
+
+        return (bool) $this->getToUpperService()->config('trim', true);
+    }
+
+    protected function resolveEncoding(): string
+    {
+        if (property_exists($this, 'uppercase_encoding') && is_string($this->uppercase_encoding)) {
+            return $this->uppercase_encoding;
+        }
+
+        return (string) $this->getToUpperService()->config('encoding', mb_internal_encoding());
+    }
+
+    protected function mergeConfiguredAttributes(string $configKey, ?string $property = null): array
+    {
+        $property ??= $configKey;
+        $configured = $this->normalizeArray($this->getToUpperService()->config($configKey, []));
+        $modelValues = [];
+
+        if (property_exists($this, $property)) {
+            $modelValues = $this->normalizeArray($this->{$property});
+        }
+
+        return array_values(array_unique([...$configured, ...$modelValues]));
+    }
+
+    protected function normalizeArray(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, fn ($item) => is_string($item) && $item !== ''));
+    }
+
+    protected function getToUpperService(): ToUpper
+    {
+        return app(ToUpper::class);
     }
 }

--- a/tests/Feature/HasToUpperTest.php
+++ b/tests/Feature/HasToUpperTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace RiseTechApps\ToUpper\Tests\Feature;
+
+use Illuminate\Database\Eloquent\Model;
+use RiseTechApps\ToUpper\Tests\TestCase;
+use RiseTechApps\ToUpper\Traits\HasToUpper;
+
+class HasToUpperTest extends TestCase
+{
+    /** @test */
+    public function it_converts_strings_to_uppercase_before_setting_attribute(): void
+    {
+        $model = new class extends Model {
+            use HasToUpper;
+
+            protected $guarded = [];
+        };
+
+        $model->setAttribute('name', ' João Silva ');
+
+        $this->assertSame('JOÃO SILVA', $model->getAttribute('name'));
+    }
+
+    /** @test */
+    public function it_respects_the_only_upper_list(): void
+    {
+        $model = new class extends Model {
+            use HasToUpper;
+
+            protected $guarded = [];
+            protected array $only_upper = ['code'];
+        };
+
+        $model->setAttribute('code', 'abc');
+        $model->setAttribute('name', 'john');
+
+        $this->assertSame('ABC', $model->getAttribute('code'));
+        $this->assertSame('john', $model->getAttribute('name'));
+    }
+
+    /** @test */
+    public function it_respects_the_no_upper_list(): void
+    {
+        $model = new class extends Model {
+            use HasToUpper;
+
+            protected $guarded = [];
+            protected array $no_upper = ['email'];
+        };
+
+        $model->setAttribute('email', 'john@example.com');
+        $model->setAttribute('city', 'porto alegre');
+
+        $this->assertSame('john@example.com', $model->getAttribute('email'));
+        $this->assertSame('PORTO ALEGRE', $model->getAttribute('city'));
+    }
+
+    /** @test */
+    public function it_ignores_morph_attributes(): void
+    {
+        $model = new class extends Model {
+            use HasToUpper;
+
+            protected $guarded = [];
+        };
+
+        $model->setAttribute('attachable_type', 'App\\Models\\File');
+        $model->setAttribute('attachable_id', 'uuid-value');
+
+        $this->assertSame('App\\Models\\File', $model->getAttribute('attachable_type'));
+        $this->assertSame('uuid-value', $model->getAttribute('attachable_id'));
+    }
+
+    /** @test */
+    public function it_allows_custom_encoding_and_trim_flags(): void
+    {
+        $model = new class extends Model {
+            use HasToUpper;
+
+            protected $guarded = [];
+            protected string $uppercase_encoding = 'UTF-8';
+            protected bool $uppercase_trim = false;
+        };
+
+        $model->setAttribute('nickname', ' joão ');
+
+        $this->assertSame(' JOÃO ', $model->getAttribute('nickname'));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace RiseTechApps\ToUpper\Tests;
+
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use RiseTechApps\ToUpper\ToUpperServiceProvider;
+
+abstract class TestCase extends OrchestraTestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [ToUpperServiceProvider::class];
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable defaults for uppercase handling and publishable config
- register a concrete ToUpper service with facade binding
- update HasToUpper trait to normalize before parent call and respect config/overrides
- document usage and add Orchestra Testbench coverage

## Testing
- composer install *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_690c0a1ce6b48320992c1543c2a14930